### PR TITLE
fix: improve HTML and CSS naming pattern to fix conflict with GCode Preview panel

### DIFF
--- a/octoprint_E3V3SEPrintJobDetails/__init__.py
+++ b/octoprint_E3V3SEPrintJobDetails/__init__.py
@@ -991,7 +991,7 @@ class E3v3seprintjobdetailsPlugin(octoprint.plugin.StartupPlugin,
 
 
 __plugin_pythoncompat__ = ">=3,<4"  # Only Python 3
-__plugin_version__ = "0.0.2.9"
+__plugin_version__ = "0.0.3.0"
 
 
 def __plugin_load__():

--- a/octoprint_E3V3SEPrintJobDetails/static/js/e3v3seprintjobdetails.js
+++ b/octoprint_E3V3SEPrintJobDetails/static/js/e3v3seprintjobdetails.js
@@ -6,9 +6,9 @@ $(function () {
             console.log("Attempting to show popup:", message);
 
             // If modal does not exist, create it
-            if ($("#customPopup").length === 0) {
+            if ($("#e3v3sejd-customPopup").length === 0) {
                 $("body").append(`
-                    <div id="customPopup" class="modal fade" tabindex="-1" role="dialog">
+                    <div id="e3v3sejd-customPopup" class="e3v3sejd modal fade" tabindex="-1" role="dialog">
                         <div class="modal-dialog modal-dialog-centered" role="document">
                             <div class="modal-content" style="border-radius: 10px; overflow: hidden;">
                                 <div class="modal-header" style="background: linear-gradient(135deg, #007bff, #6610f2); color: white;">
@@ -20,7 +20,7 @@ $(function () {
                                     </button>
                                 </div>
                                 <div class="modal-body text-center">
-                                    <p id="customPopupMessage" class="mb-3" style="font-size: 16px; font-weight: 500;"></p>
+                                    <p id="e3v3sejd-customPopupMessage" class="mb-3" style="font-size: 16px; font-weight: 500;"></p>
                                     <div class="spinner">
                                         <div class="double-bounce1"></div>
                                         <div class="double-bounce2"></div>
@@ -34,14 +34,14 @@ $(function () {
                 // Add custom CSS styles
                 $("head").append(`
                     <style>
-                        .spinner {
+                        .e3v3sejd .spinner {
                             width: 50px;
                             height: 50px;
                             position: relative;
                             margin: 0 auto;
                         }
         
-                        .double-bounce1, .double-bounce2 {
+                        .e3v3sejd .double-bounce1, .double-bounce2 {
                             width: 100%;
                             height: 100%;
                             border-radius: 50%;
@@ -50,14 +50,14 @@ $(function () {
                             position: absolute;
                             top: 0;
                             left: 0;
-                            animation: bounce 2.0s infinite ease-in-out;
+                            animation: e3v3sejd-bounce 2.0s infinite ease-in-out;
                         }
         
-                        .double-bounce2 {
+                        .e3v3sejd .double-bounce2 {
                             animation-delay: -1.0s;
                         }
         
-                        @keyframes bounce {
+                        @keyframes e3v3sejd-bounce {
                             0%, 100% { transform: scale(0.0); }
                             50% { transform: scale(1.0); }
                         }
@@ -66,32 +66,32 @@ $(function () {
             }
 
             // Set the message and show the modal
-            $("#customPopupMessage").text(message);
-            $("#customPopup").modal("show");
+            $("#e3v3sejd-customPopupMessage").text(message);
+            $("#e3v3sejd-customPopup").modal("show");
         }
 
         function closePopup() {
             console.log("Closing popup...");
-            $("#customPopup").modal("hide");
+            $("#e3v3sejd-customPopup").modal("hide");
         }
 
         function closeErrorPopup() {
             console.log("Closing popup...");
-            $("#errorPopup").modal("hide");
+            $("#e3v3sejd-errorPopup").modal("hide");
         }
 
          function closePurgePopup() {
             console.log("Closing popup...");
-            $("#purgePopup").modal("hide");
+            $("#e3v3sejd-purgePopup").modal("hide");
         }
 
         function showErrorPopup(message) {
             console.log("Attempting to show error popup:", message);
 
             // If modal does not exist, create it
-            if ($("#errorPopup").length === 0) {
+            if ($("#e3v3sejd-errorPopup").length === 0) {
                 $("body").append(`
-                    <div id="errorPopup" class="modal fade" tabindex="-1" role="dialog">
+                    <div id="e3v3sejd-errorPopup" class="e3v3sejd modal fade" tabindex="-1" role="dialog">
                         <div class="modal-dialog modal-dialog-centered" role="document">
                             <div class="modal-content" style="border-radius: 10px; overflow: hidden;">
                                 <div class="modal-header" style="background: linear-gradient(135deg, #dc3545, #b30000); color: white;">
@@ -103,7 +103,7 @@ $(function () {
                                     </button>
                                 </div>
                                 <div class="modal-body text-center">
-                                    <p id="errorPopupMessage" class="mb-3" style="font-size: 16px; font-weight: 500;"></p>
+                                    <p id="e3v3sejd-errorPopupMessage" class="mb-3" style="font-size: 16px; font-weight: 500;"></p>
                                     <div class="error-animation">
                                         <div class="circle">
                                             <div class="cross">
@@ -121,7 +121,7 @@ $(function () {
                 // Add custom CSS styles
                 $("head").append(`
                     <style>
-                        .error-animation {
+                        .e3v3sejd .error-animation {
                             display: flex;
                             justify-content: center;
                             align-items: center;
@@ -131,7 +131,7 @@ $(function () {
                             position: relative;
                         }
         
-                        .circle {
+                        .e3v3sejd .circle {
                             width: 60px;
                             height: 60px;
                             background-color: #dc3545;
@@ -140,16 +140,16 @@ $(function () {
                             justify-content: center;
                             align-items: center;
                             position: absolute;
-                            animation: pulse 1.5s infinite;
+                            animation: e3v3sejd-pulse 1.5s infinite;
                         }
         
-                        .cross {
+                        .e3v3sejd .cross {
                             position: relative;
                             width: 40px;
                             height: 40px;
                         }
         
-                        .cross-line {
+                        .e3v3sejd .cross-line {
                             position: absolute;
                             width: 35px;
                             height: 6px;
@@ -160,11 +160,11 @@ $(function () {
                             transform: translate(-50%, -50%) rotate(45deg);
                         }
         
-                        .cross-line:nth-child(2) {
+                        .e3v3sejd .cross-line:nth-child(2) {
                             transform: translate(-50%, -50%) rotate(-45deg);
                         }
         
-                        @keyframes pulse {
+                        @keyframes e3v3sejd-pulse {
                             0% { transform: scale(1); opacity: 0.7; }
                             50% { transform: scale(1.2); opacity: 0.5; }
                             100% { transform: scale(1); opacity: 0.7; }
@@ -174,8 +174,8 @@ $(function () {
             }
 
             // Set the message and show the modal
-            $("#errorPopupMessage").text(message);
-            $("#errorPopup").modal("show");
+            $("#e3v3sejd-errorPopupMessage").text(message);
+            $("#e3v3sejd-errorPopup").modal("show");
         }
 
 
@@ -185,9 +185,9 @@ $(function () {
             console.log("Attempting to show popup:", message);
 
             // If modal does not exist, create it
-            if ($("#purgePopup").length === 0) {
+            if ($("#e3v3sejd-purgePopup").length === 0) {
                 $("body").append(`
-            <div id="purgePopup" class="modal fade" tabindex="-1" role="dialog">
+            <div id="e3v3sejd-purgePopup" class="e3v3sejd modal fade" tabindex="-1" role="dialog">
                 <div class="modal-dialog modal-dialog-centered" role="document">
                     <div class="modal-content" style="border-radius: 10px; overflow: hidden;">
                         <div class="modal-header" style="background: linear-gradient(135deg, #007bff, #6610f2); color: white;">
@@ -199,11 +199,11 @@ $(function () {
                             </button>
                         </div>
                         <div class="modal-body text-center">
-                            <p id="purgePopupMessage" class="mb-3" style="font-size: 16px; font-weight: 500;"></p>
+                            <p id="e3v3sejd-purgePopupMessage" class="mb-3" style="font-size: 16px; font-weight: 500;"></p>
                   
                         </div>
                         <div class="modal-footer">
-                            <button type="button" id="purgeFilamentBtn" class="btn btn-primary">Purge Filament</button>
+                            <button type="button" id="e3v3sejd-purgeFilamentBtn" class="btn btn-primary">Purge Filament</button>
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">Dismiss</button>
                         </div>
                     </div>
@@ -214,14 +214,14 @@ $(function () {
                 // Add custom CSS styles (solo si aún no se añadió)
                 $("head").append(`
             <style>
-                .spinner {
+                .e3v3sejd .spinner {
                     width: 50px;
                     height: 50px;
                     position: relative;
                     margin: 0 auto;
                 }
 
-                .double-bounce1, .double-bounce2 {
+                .e3v3sejd .double-bounce1, .double-bounce2 {
                     width: 100%;
                     height: 100%;
                     border-radius: 50%;
@@ -230,14 +230,14 @@ $(function () {
                     position: absolute;
                     top: 0;
                     left: 0;
-                    animation: bounce 2.0s infinite ease-in-out;
+                    animation: e3v3sejd-bounce 2.0s infinite ease-in-out;
                 }
 
-                .double-bounce2 {
+                .e3v3sejd .double-bounce2 {
                     animation-delay: -1.0s;
                 }
 
-                @keyframes bounce {
+                @keyframes e3v3sejd-bounce {
                     0%, 100% { transform: scale(0.0); }
                     50% { transform: scale(1.0); }
                 }
@@ -245,7 +245,7 @@ $(function () {
         `);
 
                 // Bind click handler for Purge Filament
-                $(document).off("click", "#purgeFilamentBtn").on("click", "#purgeFilamentBtn", function () {
+                $(document).off("click", "#e3v3sejd-purgeFilamentBtn").on("click", "#e3v3sejd-purgeFilamentBtn", function () {
                     console.log("Purge Filament clicked");
                     self.purge_filament();
 
@@ -253,8 +253,8 @@ $(function () {
             }
 
             // Set the message and show the modal
-            $("#purgePopupMessage").text(message);
-            $("#purgePopup").modal("show");
+            $("#e3v3sejd-purgePopupMessage").text(message);
+            $("#e3v3sejd-purgePopup").modal("show");
         }
 
 

--- a/octoprint_E3V3SEPrintJobDetails/templates/settings.e3v3seprintjobdetails_plugin_settings.jinja2
+++ b/octoprint_E3V3SEPrintJobDetails/templates/settings.e3v3seprintjobdetails_plugin_settings.jinja2
@@ -6,7 +6,7 @@
 
 <style>
     /* General container styling */
-    .settings-container {
+    .e3v3sejd.settings-container {
         font-family: Arial, sans-serif;
         max-width: 600px;
         margin: auto;
@@ -18,30 +18,30 @@
         box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     }
 
-    .settings-header {
+    .e3v3sejd .settings-header {
         font-size: 1.5em;
         font-weight: bold;
         color: white;
         margin-bottom: 15px;
     }
 
-    .setting-group {
+    .e3v3sejd .setting-group {
         margin-bottom: 20px;
     }
 
-    .setting-title {
+    .e3v3sejd .setting-title {
         font-size: 1.2em;
         font-weight: bold;
         margin-bottom: 10px;
         color: white;
     }
 
-    .funkyradio div {
+    .e3v3sejd .funkyradio div {
         clear: both;
         overflow: hidden;
     }
 
-    .funkyradio label {
+    .e3v3sejd .funkyradio label {
         width: 100%;
         display: flex;
         align-items: center;
@@ -58,7 +58,7 @@
     }
 
     /* Delete the outer circle (no need for the outside circle) */
-    .funkyradio input[type="radio"] {
+    .e3v3sejd .funkyradio input[type="radio"] {
         position: absolute;
         left: 0;
         opacity: 0;
@@ -69,7 +69,7 @@
     }
 
     /* Style for circle and checkbox */
-    .funkyradio input[type="radio"]:checked+label:before {
+    .e3v3sejd .funkyradio input[type="radio"]:checked+label:before {
         content: '\2714';
         /* Popcorn (checkmark) */
         display: inline-block;
@@ -87,7 +87,7 @@
     }
 
     /* Style when radio button is unchecked */
-    .funkyradio input[type="radio"]:not(:checked)+label:before {
+    .e3v3sejd .funkyradio input[type="radio"]:not(:checked)+label:before {
         content: '';
         /* There is no check mark when it is not checked */
         display: inline-block;
@@ -102,19 +102,19 @@
     }
 
     /* Hover on the label */
-    .funkyradio label:hover {
+    .e3v3sejd .funkyradio label:hover {
         background-color: #2c2f36;
         color: #fff;
     }
 
     /* Highlight when radio button is checked */
-    .funkyradio input[type="radio"]:checked+label {
+    .e3v3sejd .funkyradio input[type="radio"]:checked+label {
         background-color: #0e304f;
         color: white;
     }
 
     /* Hint style (tooltips) */
-    .funkyradio .hint-icon2 {
+    .e3v3sejd .funkyradio .hint-icon2 {
         position: absolute;
         right: 10px;
         top: 50%;
@@ -128,37 +128,37 @@
     }
 
     /* Show the hint only when hovering over the label */
-    .funkyradio label:hover+.hint-icon2 {
+    .e3v3sejd .funkyradio label:hover+.hint-icon2 {
         visibility: visible;
         /* Show hint when hovering */
     }
 
     /* Tooltip styling */
-    .funkyradio .hint-icon2:hover {
+    .e3v3sejd .funkyradio .hint-icon2:hover {
         color: #ffffff;
     }
 
     /* Slider styles */
-    .switch-container {
+    .e3v3sejd .switch-container {
         display: flex;
         align-items: center;
         gap: 10px;
     }
 
-    .switch {
+    .e3v3sejd .switch {
         position: relative;
         display: inline-block;
         width: 34px;
         height: 20px;
     }
 
-    .switch input {
+    .e3v3sejd .switch input {
         opacity: 0;
         width: 0;
         height: 0;
     }
 
-    .slider {
+    .e3v3sejd .slider {
         position: absolute;
         cursor: pointer;
         top: 0;
@@ -170,7 +170,7 @@
         border-radius: 10px;
     }
 
-    .slider:before {
+    .e3v3sejd .slider:before {
         position: absolute;
         content: "";
         height: 14px;
@@ -182,32 +182,32 @@
         border-radius: 50%;
     }
 
-    input:checked+.slider {
+    .e3v3sejd input:checked+.slider {
         background-color: #0e304f;
     }
 
-    input:checked+.slider:before {
+    .e3v3sejd input:checked+.slider:before {
         transform: translateX(14px);
     }
 
     /* Divider styling */
-    .divider {
+    .e3v3sejd .divider {
         border-top: 1px solid #555;
         margin: 20px 0;
     }
 
     /* Tooltip Styling */
-    label:hover {
+    .e3v3sejd label:hover {
         color: #fff;
         background-color: #2c2f36;
     }
 
-    label:hover+.tooltip {
+    .e3v3sejd label:hover+.tooltip {
         display: block;
     }
 </style>
 
-<div class="settings-container">
+<div class="e3v3sejd settings-container">
 
     <!-- Command Display Options -->
     <div class="setting-group">

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_E3V3SEPrintJobDetails"
 plugin_name = "OctoPrint-E3V3SEPrintJobDetails"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.0.2.9"
+plugin_version = "0.0.3.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Improve HTML and CSS naming patterns to avoid conflict with other components like GCode Preview Panel, that was broken by previows version of this changes.

This improvement consist of add ID and Class prefixes to use with CSS Selectors to avoid conflict with other components of OctoPrint or other plugins.

**The reason of conlict:**

The components used to create the filament switching dialogs were conflicting with other CSS files.

By example, before this change, the GCode Preview scroll bars and scroll system was boken due CSS selector conflict:

<img width="589" height="589" alt="GCode Viewer (Before)" src="https://github.com/user-attachments/assets/e86befe8-3447-4861-9b69-ecdaaa683fc3" />

**Results:**

After changes, with no CSS conflict, GCode Preview works properly again:

<img width="591" height="592" alt="image" src="https://github.com/user-attachments/assets/539c6363-e663-41da-9d8a-92a2c32540db" />

These changes were tested locally and the filament switching continues to works properly.